### PR TITLE
Allow Crumble on Touch Blocks to destroy static movers

### DIFF
--- a/Ahorn/entities/crumbleBlockOnTouch.jl
+++ b/Ahorn/entities/crumbleBlockOnTouch.jl
@@ -9,7 +9,8 @@ using ..Ahorn, Maple
     height::Integer=Maple.defaultBlockHeight,
     blendin::Bool=true,
     persistent::Bool=false,
-    delay::Number=0.1
+    delay::Number=0.1,
+    destroyStaticMovers::Bool=false
 )
 
 const placements = Ahorn.PlacementDict(

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -7,6 +7,8 @@ placements.entities.ShroomHelper/CrumbleBlockOnTouch.tooltips.delay=How long unt
 placements.entities.ShroomHelper/CrumbleBlockOnTouch.tooltips.blendin=Blends the block with the walls it touches, making it less apparent.
 placements.entities.ShroomHelper/CrumbleBlockOnTouch.tooltips.persistent=Once broken, the block will remain that way, even if the player dies.
 placements.entities.ShroomHelper/CrumbleBlockOnTouch.tooltips.tiletype=Determines the visual appearance of the wall.
+placements.entities.ShroomHelper/CrumbleBlockOnTouch.tooltips.destroyStaticMovers=Destroy attached entities when the block breaks.
+placements.entities.ShroomHelper/CrumbleBlockOnTouch.names.destroyStaticMovers=Destroy Attached
 
 # Killer Heart Gate
 placements.entities.ShroomHelper/KillerHeartGate.tooltips.triggerDistance=The distance from the heart gate the player needs to be before it starts closing, in pixels.

--- a/Code/Entities/CrumbleBlockOnTouch.cs
+++ b/Code/Entities/CrumbleBlockOnTouch.cs
@@ -11,11 +11,12 @@ namespace Celeste.Mod.ShroomHelper.Entities {
         public float delay;
         public bool triggered;
         public bool blendIn;
+        public bool destroyStaticMovers;
 
         private readonly char tileType;
         private EntityID id;
 
-        public CrumbleBlockOnTouch(Vector2 position, char tileType, float width, float height, bool blendIn, bool persistent, float delay, EntityID id)
+        public CrumbleBlockOnTouch(Vector2 position, char tileType, float width, float height, bool blendIn, bool persistent, float delay, bool destroyStaticMovers, EntityID id)
             : base(position, width, height, safe: true) {
             Depth = -12999;
             this.id = id;
@@ -23,11 +24,12 @@ namespace Celeste.Mod.ShroomHelper.Entities {
             this.blendIn = blendIn;
             this.delay = delay;
             permanent = persistent;
+            this.destroyStaticMovers = destroyStaticMovers;
             SurfaceSoundIndex = SurfaceIndex.TileToIndex[this.tileType];
         }
 
         public CrumbleBlockOnTouch(EntityData data, Vector2 offset, EntityID id)
-            : this(data.Position + offset, data.Char("tiletype", 'm'), data.Width, data.Height, data.Bool("blendin", true), data.Bool("persistent"), data.Float("delay"), id) {
+            : this(data.Position + offset, data.Char("tiletype", 'm'), data.Width, data.Height, data.Bool("blendin", true), data.Bool("persistent"), data.Float("delay"), data.Bool("destroyStaticMovers"), id) {
         }
 
         public override void Awake(Scene scene) {
@@ -78,6 +80,10 @@ namespace Celeste.Mod.ShroomHelper.Entities {
             if (permanent) {
                 Level level = SceneAs<Level>();
                 level.Session.DoNotLoad.Add(id);
+            }
+
+            if (destroyStaticMovers) {
+                DestroyStaticMovers();
             }
 
             RemoveSelf();

--- a/Loenn/entities/crumble_block_on_touch.lua
+++ b/Loenn/entities/crumble_block_on_touch.lua
@@ -2,7 +2,7 @@ local fakeTilesHelper = require("helpers.fake_tiles")
 
 local crumble_block_on_touch = {}
 
-crumble_block_on_touch.name = "ShroomHelper/CrumbleBlockOnTouch" 
+crumble_block_on_touch.name = "ShroomHelper/CrumbleBlockOnTouch"
 crumble_block_on_touch.depth = 0
 crumble_block_on_touch.placements = {
     name = "crumble_block_on_touch",
@@ -13,6 +13,7 @@ crumble_block_on_touch.placements = {
         blendin = true,
         persistent = false,
         delay = 0.1,
+        destroyStaticMovers = false,
     }
 }
 

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -12,6 +12,8 @@ entities.ShroomHelper/CrumbleBlockOnTouch.attributes.description.blendin=Blends 
 entities.ShroomHelper/CrumbleBlockOnTouch.attributes.description.persistent=Once broken, the block will remain that way, even if the player dies.
 entities.ShroomHelper/CrumbleBlockOnTouch.attributes.description.delay=How long until the block crumbles, in seconds.
 entities.ShroomHelper/CrumbleBlockOnTouch.attributes.description.tiletype=Determines the visual appearance of the wall.
+entities.ShroomHelper/CrumbleBlockOnTouch.attributes.description.destroyStaticMovers=Destroy attached entities when the block breaks.
+entities.ShroomHelper/CrumbleBlockOnTouch.attributes.name.destroyStaticMovers=Destroy Attached
 
 # Killer Heart Gate
 entities.ShroomHelper/KillerHeartGate.placements.name.killer_heart_gate=Killer Heart Gate


### PR DESCRIPTION
Adds an option to Crumble on Touch Blocks that will make them destroy attached static movers when broken.