### PR TITLE
add enable flag and read flag to shroom book interaction

### DIFF
--- a/Ahorn/entities/shroomBookInteraction.jl
+++ b/Ahorn/entities/shroomBookInteraction.jl
@@ -7,7 +7,9 @@ using ..Ahorn, Maple
     y::Integer,
     width::Integer=Maple.defaultBlockWidth,
     height::Integer=Maple.defaultBlockHeight, 
-    assetKey::String="shroompage"
+    assetKey::String="shroompage",
+    enableFlag::String="",
+    readFlag::String=""
 )
 
 const placements = Ahorn.PlacementDict(

--- a/Ahorn/lang/en_gb.lang
+++ b/Ahorn/lang/en_gb.lang
@@ -19,6 +19,8 @@ placements.entities.ShroomHelper/RealityDistortionField.tooltips.rippleAreaMulti
 
 # Shroom Book Interaction
 placements.entities.ShroomHelper/ShroomBookInteraction.tooltips.assetKey=The image to display relative to Graphics/Atlases/Gui (do not include .png).
+placements.entities.ShroomHelper/ShroomBookInteraction.tooltips.enableFlag=If specified, the entity will only load when the flag is True. Use ! prefix to invert.
+placements.entities.ShroomHelper/ShroomBookInteraction.tooltips.readFlag=A flag to set when the player finishes reading. Use ! prefix to clear.
 
 # Shroom Dash Switch
 placements.entities.ShroomHelper/ShroomDashSwitch.tooltips.side=The direction the switch is facing.

--- a/Code/Entities/ShroomBook.cs
+++ b/Code/Entities/ShroomBook.cs
@@ -7,11 +7,15 @@ namespace Celeste.Mod.ShroomHelper.Entities {
     public class ShroomBook : CutsceneEntity {
         private readonly Player player;
         private readonly string bookTextKey;
+        private readonly string readFlag;
+        private readonly bool readFlagInverted;
         private PoemPage poem;
 
-        public ShroomBook(Player player, string bookTextKey) {
+        public ShroomBook(Player player, string bookTextKey, string readFlag, bool readFlagInverted) {
             this.player = player;
             this.bookTextKey = bookTextKey;
+            this.readFlag = readFlag;
+            this.readFlagInverted = readFlagInverted;
         }
 
         public override void OnBegin(Level level) {
@@ -23,6 +27,9 @@ namespace Celeste.Mod.ShroomHelper.Entities {
             player.StateMachine.State = Player.StNormal;
             if (poem != null) {
                 poem.RemoveSelf();
+            }
+            if(readFlag != "") {
+                level.Session.SetFlag(readFlag, !readFlagInverted);
             }
         }
 

--- a/Code/Entities/ShroomBook.cs
+++ b/Code/Entities/ShroomBook.cs
@@ -11,7 +11,7 @@ namespace Celeste.Mod.ShroomHelper.Entities {
         private readonly bool readFlagInverted;
         private PoemPage poem;
 
-        public ShroomBook(Player player, string bookTextKey, string readFlag, bool readFlagInverted) {
+        public ShroomBook(Player player, string bookTextKey, string readFlag = "", bool readFlagInverted = false) {
             this.player = player;
             this.bookTextKey = bookTextKey;
             this.readFlag = readFlag;
@@ -25,10 +25,8 @@ namespace Celeste.Mod.ShroomHelper.Entities {
         public override void OnEnd(Level level) {
             player.StateMachine.Locked = false;
             player.StateMachine.State = Player.StNormal;
-            if (poem != null) {
-                poem.RemoveSelf();
-            }
-            if(readFlag != "") {
+            poem?.RemoveSelf();
+            if (!string.IsNullOrWhiteSpace(readFlag)) {
                 level.Session.SetFlag(readFlag, !readFlagInverted);
             }
         }

--- a/Code/Entities/ShroomBookInteraction.cs
+++ b/Code/Entities/ShroomBookInteraction.cs
@@ -19,14 +19,14 @@ namespace Celeste.Mod.ShroomHelper.Entities {
             Collider = new Hitbox(data.Width, data.Height);
             assetKey = data.Attr("assetKey", "shroompage");
 
-            enableFlag = data.Attr("enableFlag");
-            if(enableFlag[0] == '!') {
+            enableFlag = data.Attr("enableFlag", "");
+            if(enableFlag.Length > 1 && enableFlag[0] == '!') {
                 enableFlagInverted = true;
                 enableFlag = enableFlag[1..];
             }
 
-            readFlag = data.Attr("readFlag");
-            if(readFlag[0] == '!') {
+            readFlag = data.Attr("readFlag", "");
+            if(readFlag.Length > 1 && readFlag[0] == '!') {
                 readFlagInverted = true;
                 readFlag = readFlag[1..];
             }

--- a/Code/Entities/ShroomBookInteraction.cs
+++ b/Code/Entities/ShroomBookInteraction.cs
@@ -20,15 +20,13 @@ namespace Celeste.Mod.ShroomHelper.Entities {
             assetKey = data.Attr("assetKey", "shroompage");
 
             enableFlag = data.Attr("enableFlag");
-            if(enableFlag[0] == '!')
-            {
+            if(enableFlag[0] == '!') {
                 enableFlagInverted = true;
                 enableFlag = enableFlag[1..];
             }
 
             readFlag = data.Attr("readFlag");
-            if(readFlag[0] == '!')
-            {
+            if(readFlag[0] == '!') {
                 readFlagInverted = true;
                 readFlag = readFlag[1..];
             }
@@ -43,8 +41,7 @@ namespace Celeste.Mod.ShroomHelper.Entities {
             Talker.PlayerMustBeFacing = false;
         }
 
-        public override void Awake(Scene scene)
-        {
+        public override void Awake(Scene scene) {
 
             if(enableFlag == "" || SceneAs<Level>().Session.GetFlag(enableFlag) != enableFlagInverted) {
                 base.Awake(scene);

--- a/Code/Entities/ShroomBookInteraction.cs
+++ b/Code/Entities/ShroomBookInteraction.cs
@@ -5,7 +5,6 @@ using Monocle;
 namespace Celeste.Mod.ShroomHelper.Entities {
     [CustomEntity("ShroomHelper/ShroomBookInteraction")]
     public class ShroomBookInteraction : Entity {
-        public const string FlagPrefix = "it_";
         public TalkComponent Talker;
         public string assetKey;
         public string enableFlag;
@@ -20,15 +19,15 @@ namespace Celeste.Mod.ShroomHelper.Entities {
             assetKey = data.Attr("assetKey", "shroompage");
 
             enableFlag = data.Attr("enableFlag", "");
-            if(enableFlag.Length > 1 && enableFlag[0] == '!') {
+            if (!string.IsNullOrWhiteSpace(enableFlag) && enableFlag[0] == '!') {
                 enableFlagInverted = true;
-                enableFlag = enableFlag[1..];
+                enableFlag = enableFlag.Substring(1);
             }
 
             readFlag = data.Attr("readFlag", "");
-            if(readFlag.Length > 1 && readFlag[0] == '!') {
+            if (!string.IsNullOrWhiteSpace(readFlag) && readFlag[0] == '!') {
                 readFlagInverted = true;
-                readFlag = readFlag[1..];
+                readFlag = readFlag.Substring(1);
             }
 
 
@@ -42,11 +41,9 @@ namespace Celeste.Mod.ShroomHelper.Entities {
         }
 
         public override void Awake(Scene scene) {
-
-            if(enableFlag == "" || SceneAs<Level>().Session.GetFlag(enableFlag) != enableFlagInverted) {
+            if (string.IsNullOrWhiteSpace(enableFlag) || SceneAs<Level>().Session.GetFlag(enableFlag) != enableFlagInverted) {
                 base.Awake(scene);
-            }
-            else {
+            } else {
                 RemoveSelf();
             }
         }

--- a/Code/Entities/ShroomBookInteraction.cs
+++ b/Code/Entities/ShroomBookInteraction.cs
@@ -8,12 +8,31 @@ namespace Celeste.Mod.ShroomHelper.Entities {
         public const string FlagPrefix = "it_";
         public TalkComponent Talker;
         public string assetKey;
+        public string enableFlag;
+        public string readFlag;
+        public bool enableFlagInverted = false;
+        public bool readFlagInverted = false;
 
         public ShroomBookInteraction(EntityData data, Vector2 offset)
             : base(data.Position + offset) {
 
             Collider = new Hitbox(data.Width, data.Height);
             assetKey = data.Attr("assetKey", "shroompage");
+
+            enableFlag = data.Attr("enableFlag");
+            if(enableFlag[0] == '!')
+            {
+                enableFlagInverted = true;
+                enableFlag = enableFlag[1..];
+            }
+
+            readFlag = data.Attr("readFlag");
+            if(readFlag[0] == '!')
+            {
+                readFlagInverted = true;
+                readFlag = readFlag[1..];
+            }
+
 
             Vector2 drawAt = new(data.Width / 2, 0f);
             if (data.Nodes.Length != 0) {
@@ -24,8 +43,19 @@ namespace Celeste.Mod.ShroomHelper.Entities {
             Talker.PlayerMustBeFacing = false;
         }
 
+        public override void Awake(Scene scene)
+        {
+
+            if(enableFlag == "" || SceneAs<Level>().Session.GetFlag(enableFlag) != enableFlagInverted) {
+                base.Awake(scene);
+            }
+            else {
+                RemoveSelf();
+            }
+        }
+
         public void OnTalk(Player player) {
-            Scene.Add(new ShroomBook(player, assetKey));
+            Scene.Add(new ShroomBook(player, assetKey, readFlag, readFlagInverted));
         }
     }
 }

--- a/Loenn/entities/shroom_book_interaction.lua
+++ b/Loenn/entities/shroom_book_interaction.lua
@@ -9,7 +9,9 @@ shroom_book_interaction.placements = {
     data = {
         width = 8,
         height = 8,
-        assetKey = "shroompage"
+        assetKey = "shroompage",
+        enableFlag = "",
+        readFlag = ""
     }
 }
 

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -49,8 +49,6 @@ entities.ShroomHelper/ShroomBookInteraction.attributes.description.assetKey=The 
 entities.ShroomHelper/ShroomBookInteraction.attributes.description.enableFlag=If specified, the entity will only load when the flag is True. Use ! prefix to invert.
 entities.ShroomHelper/ShroomBookInteraction.attributes.description.readFlag=A flag to set when the player finishes reading. Use ! prefix to clear.
 
-
-
 # Double Refill Booster
 entities.ShroomHelper/DoubleRefillBooster.placements.name.double_refill_booster=Double Refill Booster
 

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -46,6 +46,10 @@ entities.ShroomHelper/ShroomDashSwitch.attributes.description.windPatternOnColli
 # Shroom Book Interaction
 entities.ShroomHelper/ShroomBookInteraction.placements.name.shroom_book_interaction=Shroom Book Interaction
 entities.ShroomHelper/ShroomBookInteraction.attributes.description.assetKey=The image to display relative to Graphics/Atlases/Gui (do not include .png).
+entities.ShroomHelper/ShroomBookInteraction.attributes.description.enableFlag=If specified, the entity will only load when the flag is True. Use ! prefix to invert.
+entities.ShroomHelper/ShroomBookInteraction.attributes.description.readFlag=A flag to set when the player finishes reading. Use ! prefix to clear.
+
+
 
 # Double Refill Booster
 entities.ShroomHelper/DoubleRefillBooster.placements.name.double_refill_booster=Double Refill Booster


### PR DESCRIPTION
This adds a couple of flags to the ShroomBookInteraction entity. 

enableFlag determines whether the entity appears on load and can be used the make the entity only appear in a room under specific circumstances or show a different image depending on a flag (by having two entities with inverse enableFlag conditions). The flag can be inverted with a ! prefix so that the entity only appears when the flag is false.

readFlag is set or cleared after the player finishes reading. This can be used to trigger other events using an activator trigger (here is an example using the flag to trigger a dialogue response to the note https://www.youtube.com/watch?v=CvndGXE4KXk). The flag can be prefixed with ! to clear it instead of setting it.